### PR TITLE
proposed changes for Neo4j 4.2 logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+*.iml
+.idea/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
 			<version>${neo4j.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j2.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>2.12.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
 			<version>${neo4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j2.version}</version>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<version>2.12.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -64,6 +64,11 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<systemPropertyVariables>
+						<log4j2.debug>true</log4j2.debug>
+					</systemPropertyVariables>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/test/java/com/example/neo4j/log4j2/FixShadedClassLoader.java
+++ b/src/test/java/com/example/neo4j/log4j2/FixShadedClassLoader.java
@@ -1,0 +1,17 @@
+package com.example.neo4j.log4j2;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.regex.Pattern;
+
+public class FixShadedClassLoader extends ClassLoader {
+
+    private final Pattern filterRegex = Pattern.compile(".*neo4j-logging.*Log4j2Plugins\\.dat$");
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Enumeration<URL> resources = super.getResources(name);
+        return new PredicateEnumeration<>(url -> !filterRegex.matcher(url.toString()).matches(), resources);
+    }
+}

--- a/src/test/java/com/example/neo4j/log4j2/LoggingTest.java
+++ b/src/test/java/com/example/neo4j/log4j2/LoggingTest.java
@@ -6,11 +6,11 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.neo4j.logging.shaded.log4j.LogManager;
 
 class LoggingTest {
 

--- a/src/test/java/com/example/neo4j/log4j2/LoggingTest.java
+++ b/src/test/java/com/example/neo4j/log4j2/LoggingTest.java
@@ -4,13 +4,21 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.neo4j.logging.shaded.log4j.LogManager;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
+import org.neo4j.graphdb.GraphDatabaseService;
 
 class LoggingTest {
 
@@ -38,12 +46,21 @@ class LoggingTest {
 	}
 
 	@Test
-	void logMessageShouldBePrintedToConsole() {
+	void logMessageShouldBePrintedToConsole() throws IOException {
+
+		Thread.currentThread().setContextClassLoader(new FixShadedClassLoader());
+
 		LogManager.getLogger(LoggingTest.class).info("Hello World.");
 
 		String consoleOutput = standardOutCapture.toString(StandardCharsets.UTF_8);
 		Assertions.assertEquals(
 				"[main] INFO  com.example.neo4j.log4j2.LoggingTest - Hello World." + System.lineSeparator(),
 				consoleOutput);
+
+		Path databaseDirectory = Files.createTempDirectory("neo4j");
+		StatusLogger.getLogger().error("starting db in " + databaseDirectory );
+		DatabaseManagementService dbms = new DatabaseManagementServiceBuilder(databaseDirectory).build();
+		GraphDatabaseService db = dbms.database("neo4j");
+		dbms.shutdown();
 	}
 }

--- a/src/test/java/com/example/neo4j/log4j2/PredicateEnumeration.java
+++ b/src/test/java/com/example/neo4j/log4j2/PredicateEnumeration.java
@@ -1,0 +1,37 @@
+package com.example.neo4j.log4j2;
+
+import java.util.Enumeration;
+import java.util.function.Predicate;
+
+public class PredicateEnumeration<T> implements Enumeration<T> {
+
+    private final Predicate<T> predicate;
+    private final Enumeration<T> delegate;
+    private T next;
+
+    public PredicateEnumeration(Predicate<T> predicate, Enumeration<T> delegate) {
+        this.predicate = predicate;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasMoreElements() {
+        boolean hasNext = delegate.hasMoreElements();
+        if (hasNext) {
+            next = delegate.nextElement();
+            if (predicate.test(next)) {
+                return true;
+            } else {
+                return hasMoreElements();
+            }
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public T nextElement() {
+        return next;
+    }
+
+}

--- a/src/test/resources/log4j2-test.yaml
+++ b/src/test/resources/log4j2-test.yaml
@@ -1,0 +1,13 @@
+Configuration:
+    name: DefaultTest"
+    Appenders:
+        Console:
+            name: STDOUT
+            target: SYSTEM_OUT
+            PatternLayout:
+                pattern: "[%t] %-5p %c - %m%n"
+    Loggers:
+        Root:
+            Level: debug
+            AppenderRef:
+                ref: STDOUT


### PR DESCRIPTION
In the test class  I'm using the LogManager being shaded into Neo4j instead of the regular one from Log4j2. Since we no longer depend on non-shaded log4j2 I've removed the dependency in pom.xml

For a unknown reason I wasn't able to read the config in json format using the shaded log manager. Therefore I'm providing a yaml variant of this.

Additionall I've added a sys variable to enable verbose log4j2 tracing.

WIth these changes the test passes.